### PR TITLE
Add Prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const windowOptions = {
   frame: true,
   minHeight: 500,
   minWidth: 800,
-  title: 'Peerdrop'
+  title: 'Peerdrop',
 }
 
 //

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "extract-zip": "=1.6.0",
     "husky": "^0.13.3",
     "nodemon": "^1.11.0",
+    "prettier": "1.2.2",
     "progress-stream": "2.0.0",
     "progressbar.js": "1.0.1",
     "stream-body": "^1.0.5",
@@ -21,8 +22,15 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "./node_modules/.bin/nodemon --ext js,html --ignore node_modules/ ./node_modules/.bin/electron ./index.js",
+	"precommit": "lint-staged",
     "postcheckout": "bin/postcheckout",
     "build-linux": "build --linux zip deb"
+  },
+  "lint-staged": {
+    "*.js": [
+	  "prettier --write --no-semi --single-quote --trailing-comma es5",
+	  "git add"
+	]
   },
   "build": {
     "appId": "peerdrop.offlinefirst",

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ const read = f => fs.readFileSync(path.join(__dirname, f), 'utf8')
 const opts = {
   key: read('./keys/key.pem'),
   cert: read('./keys/cert.pem'),
-  rejectUnauthorized: false
+  rejectUnauthorized: false,
 }
 
 module.exports = cb => {


### PR DESCRIPTION
[prettier](https://github.com/prettier/prettier) is a decent JavaScript auto-formatter. No need to either argue about code style or even write in specific style, `prettier` takes care.

This PR both adds the infrastructure to run `prettier` before a commit and formats the code. All the infra changes are in `package.json`.

The suggested style is similar to `standard`, I added trailing-commas, but I don’t feel strongly about any of the options, so if you like the general idea, but dislike some of the options, feel free to override them.

Editor integration details: https://github.com/prettier/prettier#editor-integration
What it took me to set it up in `neovim`: https://github.com/nb/dotfiles/commit/7839ff69ef8b6a807cb746630caf9a330e3647bd