### PR TITLE
add peer-to-peer git daemon and helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,37 @@
-# SYNOPSIS
-An airdrop clone
+# [PeerDrop](https://0x00a.github.io/peerdrop/)
 
-# AVATAR
+**A FLOSS, cross-platform Airdrop alternative**
+
+Made at [Offline Camp](http://offlinefirst.org/camp/)
+
+## SETUP
+
+After cloning and installing dependecies, run **`npm start`**. It launches the [Electron](https://electron.atom.io/) binary, wrapped in a [nodemon](https://nodemon.io/) to make development more comfortable. 
+
+You can also run `npm run git-deamon` to [launch a one-off git server](https://gist.github.com/datagrok/5080545). It will tell you how others can then clone and pull directly from your machine.
+
+## AVATAR
 
 Drop an image to your own bubble at the bottom. PeerDrop will persist this at `~/avatar/`
 
 ![image](https://cloud.githubusercontent.com/assets/170145/25565945/3aaed0e0-2dd1-11e7-8960-4e29b5ae6274.png)
 
 
-# BUILD
+## BUILD
 
-## Linux
+### Linux
 
 `npm run build-linux` builds deb/zip packages
 
-### System Dependencies
+#### System Dependencies
 
-#### Arch Linux
+##### Arch Linux
 
 * graphicsmagick
 * libicns (AUR)
 
-## Mac
+### Mac
 
 `npm run build-mac` builds app/dmg/zip packages
 
-# RUN
-To run the app, use the bin in the `node_modules` directory.
 
-```bash
-./node_modules/.bin/electron ./index.js
-```
-
-or run with nodemon to restart on changes
-
-```bash
-./node_modules/.bin/nodemon ./node_modules/.bin/electron ./index.js
-```
-
-which is also wrapped with
-
-```bash
-npm start
-```

--- a/ipAndHostnameInfo.js
+++ b/ipAndHostnameInfo.js
@@ -1,0 +1,15 @@
+var ip = require('ip');
+var os = require('os')
+var clc = require('cli-color');
+
+console.log(" ")
+console.log("started the git daemon")
+console.log(" ")
+console.log(clc.yellowBright('others can now clone and pull from you by doing things like:'));
+console.log(" ")
+console.log(`git clone git://${ip.address()}/ peerdrop`)
+console.log("cd peerdrop ")
+console.log(`git remote add ${os.hostname()} git://${ip.address()}/`)
+console.log(`git pull ${os.hostname()}`)
+console.log(" ")
+

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "An airdrop clone",
   "main": "index.js",
   "dependencies": {
+    "cli-color": "^1.2.0",
     "clone": "2.1.1",
     "drag-drop": "^2.13.2",
     "extract-zip": "=1.6.0",
     "husky": "^0.13.3",
+    "ip": "^1.1.5",
     "nodemon": "^1.11.0",
     "progress-stream": "2.0.0",
     "progressbar.js": "1.0.1",
@@ -23,7 +25,8 @@
     "start": "./node_modules/.bin/nodemon --ext js,html --ignore node_modules/ ./node_modules/.bin/electron ./index.js",
     "postcheckout": "bin/postcheckout",
     "build-linux": "build --linux zip deb",
-    "build-mac": "build --mac"
+    "build-mac": "build --mac",
+    "git-daemon": "node ./ipAndHostnameInfo.js & git daemon --verbose --export-all --base-path=.git --reuseaddr --strict-paths .git/"
   },
   "build": {
     "appId": "peerdrop.offlinefirst",


### PR DESCRIPTION
This adds an npm script [to launch a temporary one-off git server and enable a peer-to-peer git workflow](https://gist.github.com/datagrok/5080545). I also added a  helper script which outputs the ip adress and some usage examples:

```bash

$ npm run git-daemon

> peerdrop@1.0.0 git-daemon /path/to/peerdrop
> node ./ipAndHostnameInfo.js & git daemon --verbose --export-all --base-path=.git --reuseaddr --strict-paths .git/

[41465] Ready to rumble
 
started the git daemon
 
others can now clone and pull from you by doing things like:
 
git clone git://192.168.x.y/ peerdrop
cd peerdrop 
git remote add myHostname git://192.168.x.y/
git pull myHostname
 

```

also updated the readme a bit...